### PR TITLE
test 11

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -237,4 +237,4 @@ jira.project.keys=\
     SYNC,\
     TR
 
-#pull.request.broadcast.message=Please only forward critical changes to Brian Chan during stabilization. Nonurgent changes should wait until the ongoing 7.4 DXP EP3 & CE GA3 release has been completed. For more details on the release timeline and status, see <a href="https://liferay.slack.com/archives/C03BTCQBQ">product-delivery</a>.
+#pull.request.broadcast.message=Please only forward critical changes to Brian Chan during stabilization. Nonurgent changes should wait until the ongoing DXP 7.4 GA1 and Portal 7.4 GA4 release has been completed. For more details on the release timeline and status, see <a href="https://liferay.slack.com/archives/C03BTCQBQ">product-delivery</a>.

--- a/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/ReleaseInfo.java
@@ -78,11 +78,15 @@ public class ReleaseInfo {
 
 	public static final int RELEASE_7_4_2_BUILD_NUMBER = 7402;
 
+	public static final int RELEASE_7_4_3_BUILD_NUMBER = 7403;
+
 	public static final int RELEASE_7_4_10_BUILD_NUMBER = 7410;
 
 	public static final int RELEASE_7_4_11_BUILD_NUMBER = 7411;
 
 	public static final int RELEASE_7_4_12_BUILD_NUMBER = 7412;
+
+	public static final int RELEASE_7_4_13_BUILD_NUMBER = 7413;
 
 	public static Date getBuildDate() {
 		DateFormat df = DateFormat.getDateInstance(DateFormat.LONG);

--- a/release.properties
+++ b/release.properties
@@ -53,11 +53,11 @@
 
     #release.info=on
 
-    release.info.build=7402
-    release.info.date=July 27, 2021
+    release.info.build=7403
+    release.info.date=October 12, 2021
     release.info.name=Liferay Community Edition Portal
-    release.info.version=7.4.2
-    release.info.version.display.name=7.4.2 CE GA3
+    release.info.version=7.4.3
+    release.info.version.display.name=7.4.3 CE GA4
 
 ##
 ## Release Source


### PR DESCRIPTION
- LPS-137451 Remove portal instance initializer (just infer from site initializer)
- LPS-137451 regen
- LPS-137509 Namespace custom extensions for system object definitions by company
- LPS-137330 add patch APIs
- LPS-137330 generate
- LPS-137330 remove pagination that is not being used
- LPS-137330 generate
- LPS-137330 adapt to remove pagination
- LPS-137330 implement tests
- LPS-137330 apply also to plural
- LPS-137330 Use LocalizedMapUtil.getLocalizedMap
- LPS-137330 emptyList
- LPS-137330 it's 8 by default, which is fine
- LPS-137330 I got errors with these 2 tests. please fix. Thx! See log:
- LPS-137400 Adds a related info item collection for blogs fort a given category
- LPS-137400 Adds language key
- LPS-137400 Build lang
- LPS-137400 this way has drawbacks.. but it's sorted
- LPS-137319 Use focused field name if fieldName from the Validation property is null
- LPS-137319 No need to evaluate if the DDMFormFieldValidationExpression is empty
- LPS-137319 Make sure to always use the predefinedValue or defaultLocale value if it is a date field
- LPS-137319 Create unit test
- LPS-105380 Remove final from variables
- LPS-105380 Remove final from parameters
- LPS-137014 Copy the old LayoutPrototype permissions for the new LayoutPageTemplateEntries
- Record reference to liferay-portal/master-private with git-commit-portal-private as 2005eeef5cf23575a1d6b4e71a2290d4afc2ca1f
- LPS-137360 Create second part of test stubs related to LPS-133365
- LPS-137272 Also take into account related collection providers when retrieving the configuration
- LPS-137272 Change so that we can filter by item type
- LPS-137272 Adds language key
- LPS-137272 Build lang
- LPS-137272 Update test
- LPS-137272 Change so that we can filter by item type
- LPS-137272 Control if we get invalid values
- LPS-137272 Also add empty array
- LPS-137272 Update poshi test
- LPS-137272 same as 7ebd042c
- LPS-137272 Inline
- COMMERCE-7066 Pass a variable instead of a defined string in CommerceEntry.viewPaginationResults()
- LRAC-8388 Limit context string values length
- LPS-137524 handle null gracefully
- LPS-136723 test object definitions
- LPS-137382 Updade build-test.xml file for new 7.0.6 legacy-ee version
- LPS-137382 Updade test.properties file for new 7.0.6 legacy-ee version
- LRCI-2432 Add additional error info
- LRCI-2432 prep next
- LPS-136740 - Add Brand Tokens.
- LPS-136740 - Add Additional missing token definitions.
- LPS-136723 more tests
- LPS-137525 Remove SchedulerLifecycleInitializer
- LPS-134038 Add missed or remove extra values correctly
- LPS-134038 baseline
- LRQA-69361 FormsParagraphField#CanSupportALinkToAURL Test Fix
- LRAC-8385 Add tests about blogs technology
- LRAC-8428 Add test about forms expected device
- LRAC-8428 Use more general macro
- LRAC-8428 Remove unnecessary macro and xpath
- LPS-137369 Add method ManagementToolbarDisplayContext.getAdditionalProps()
- LPS-137369 Add method ManagementToolbarDisplayContext.getAdditionalProps()
- LRAC-8480 Add a csv file with contacts country
- LRAC-8480 Add locator for file upload success icon
- LRAC-8480 Add macro to add CSV data source
- LRAC-8480 Modify macro to make it stable
- LRAC-8480 Add case to create dynamic segment with individual criteria uses is known and is not
- LRAC-8480 Rename case
- LRAC-8481 Add a csv file with contacts gender
- LRAC-8481 Add case to create dynamic segment with individual criteria uses boolean and does not contain
- LRAC-8481 Rename case
- LRAC-8481 Sort cases
- LRAC-8589 Add EditorShowsStaticSegmentLabel testcase
- LPS-135504 Rename conflicting key 'active-help'.
- LPS-135504 Rename conflicting key 'api-key-description'.
- LPS-135504 Rename conflicting key 'are-you-sure-you-want-to-delete-this-role'.
- LPS-135504 Rename conflicting key 'asset-entry-type'.
- LPS-135504 Rename conflicting key 'autogenerate-structure-key-description'.
- LPS-135504 Rename conflicting key 'autogenerate-template-key-description'.
- LPS-135504 Rename conflicting key 'bucket-name-help'.
- LPS-135504 Rename conflicting key 'changeable-default-language-description'.
- LPS-135504 Remove left behind key 'changeable-default-language-description' added in COMMERCE-4052
- LPS-135504 Rename conflicting key 'client-id-help'.
- LPS-135504 Rename conflicting key 'client-secret-help'.
- LPS-135504 Rename conflicting key 'connect-to-liferay-analytics-cloud-help'.
- LPS-135504 Rename conflicting key 'connection-id-help'.
- LPS-135504 Rename conflicting key 'directory-indexing-help'.
- LPS-135504 Rename conflicting key 'email-from-address-description'.
- LPS-135504 Rename conflicting key 'enabled'.
- LPS-135504 Rename conflicting key 'enabled-class-names'.
- LPS-135504 Rename conflicting key 'enabled-description'.
- LPS-135504 Rename conflicting key 'enabled-help'.
- LPS-135504 Rename conflicting key 'federated-search-key-help'.
- LPS-135504 Rename conflicting key 'file-max-size'.
- LPS-135504 Fix incorrect language key value for 'font-family-monospace'. Used by common-styles.json in layout-api module.
- LPS-135504 Rename conflicting key 'import-user-sync-strategy'.
- LPS-135504 Rename conflicting key 'library-path'.
- LPS-135504 Rename conflicting key 'maximum-number-of-tags-per-asset' in asset-auto-tagger-service.
- LPS-135504 Remove unused key 'maximum-number-of-tags-per-asset' in asset-auto-tagger-web. Usage was removed in LPS-93440 [7fb6dcf2]
- LPS-135504 Rename conflicting key 'monitoring-configuration-name'.
- LPS-135504 Rename conflicting key 'no-account-selected'.
- LPS-135504 Rename conflicting key 'no-entries-for-x-have-been-added-yet'.
- LPS-135504 Rename conflicting key 'not-contains'.
- LPS-135504 Rename conflicting key 'numeric-field-type-description'.
- LPS-135504 Rename conflicting key 'osgi-jaxrs-name'.
- LPS-135504 Rename conflicting key 'osgi-jaxrs-name-description'.
- LPS-135504 Rename conflicting key 'paragraph-field-type-description'.
- LPS-135504 Rename conflicting key 'proxy-host-help'.
- LPS-135504 Rename conflicting key 'proxy-password-help'.
- LPS-135504 Rename conflicting key 'proxy-port-help'.
- LPS-135504 Rename conflicting key 'sync-to-analytics-cloud-help'.
- LPS-135504 Rename conflicting key 'the-password-you-entered-for-the-current-password-does-not-match-your-current-password'.
- LPS-135504 Rename conflicting key 'this-configuration-is-not-saved-yet'.
- LPS-135504 Rename conflicting key 'timeout'.
- LPS-135504 Rename conflicting key 'unable-to-validate-referenced-journal-article'.
- LPS-135504 Remove unused conflicting key 'user-account-setup-failed' that was added in LPS-86515 [a8d8d44c].
- LPS-135504 Rename conflicting keys 'workflow-in-use-remove-assignements-to...'.
- LPS-135504 Rename conflicting key 'your-user-x-could-not-be-logged-in'.
- LPS-135504 Versioning.
- LPS-132615 Return only if the revision's branchId is the same as the recent branchId
- LPS-137320 Adjust WYSIWYG module relevant tests with portal acceptance layer
- LPS-137320 Adjust frontend token relevant test suite to only run acceptance tests
- LPS-137504 Preprocess HTML to remove freemarker variables
- LPS-137267 Add Feature Flag to hide information templates
- LPS-137267 Add util class to access to Feature Flag configuration
- LPS-137267 Apply Feature Flag configuration
- LPS-137243 Don't return early since we need to evaluate the display pages mappings
- LPS-137172 Add a Checkbox case to return the PieChart
- LPS-137172 Set the icon and the title for the boolean field
- LPS-137512 Avoid unwanted drag preview calculations
- LPS-137404 Added responsive component wrapper to bar chart
- LPS-137404 Fix loader component height to prevent content jumping
- LPS-137404 Fixes for unit tests using ResponsiveContainer component
- LPS-137264 Extend the session only in case it is not already expired: elapsed >= (sessionLength - sessionTimeoutOffset) and (elapsed < sessionLength)
- LPS-137264 Add 60 seconds to the timeout offset to avoid having problems with the chrome intensive throttling (see https://developer.chrome.com/blog/timer-throttling-in-chrome-88/#intensive-throttling )
- LPS-137264 Remove the console.log trace, the final user is already notified with a error popup in case the session cannot be extended
- LPS-137220 Fix getSortingURL to prevent double click to order list on first render
- LPS-136536 Add style to Numeric inputMask whe the language is Arabic
- LPS-136536 Fix test
- LPS-136536 Add className for Arabic language
- LPS-137099 Rename
- LPS-137099 Always use the same URL when the form is shared
- LPS-137099 Redirect to login page if an unauthenticated user tries to access the form via a shared URL
- LPS-137099 Fix tests
- LPS-137099 Add unit test
- LPS-137099 Inline
- LRAC-8482 Add locator for conjunction button
- LRAC-8482 Add macro to edit conjunction
- LRAC-8482 Add macro to view conjunction
- LRAC-8482 Add locator for criteria statement body
- LRAC-8482 Add macro to add nested segment field
- LRAC-8482 Add case to create nested criteria
- LRAC-8473 Modify macro to make it stable
- LRAC-8473 Modify locator to make it robust
- LRAC-8473 Remove redundant step
- LRAC-8473 Add case to search user in Add Members modal
- LRAC-8473 Rename case
- Revert "LPS-137014 Copy the old LayoutPrototype permissions for the new LayoutPageTemplateEntries"
- COMMERCE-6890 Rename channelGroupId to commerceChannelGroupId
- COMMERCE-6890 Rename CPField constants
- COMMERCE-6890 Regen
- LPS-137182 Add Journal and Dynamic Data Mapping dependencies
- LPS-137182 Implement _addDDMStructures method
- LPS-137182 Add structures
- LPS-137298 Add _addDDMTemplates method
- LPS-137298 Add templates
- LPS-137113 wrap with try/cath in _addObjectDefinitions to try POST or PUT
- LPS-137113 Sort by var name
- LPS-137113 Declare it just once
- LPS-137113 This is not safe to use as a class level variable. BundleSiteInitializer may be used concurrently (imagine 2 users hitting adding site at the same time). In the same way that the var 'long groupId' cannot be shared, so 'serviceContext' cannot be shard.
- LPS-137113 Clean up code, since serviceContext has quite a bit
- LPS-137113 That method doesn't add much value now
- LPS-137113 Like this
- LPS-137113 not needed, see ServiceContext.java:
- LPS-137542 add SeviceContext#fetchUser
- LPS-137542 Like this
- LPS-137542 Rename
- LRQA-69098 Add inputDataInNumericField macro
- LRQA-69098 Add assertDataInNumericField macro
- LRQA-69098 Add CanInputDataOnIntergerType test
- LRQA-69098 Add CanInputDataOnDecimalType test
- LRQA-69098 Add CanInputRoundDecimalNumbers test
- LRQA-69098 Add CanEditData test
- LRQA-69098 Add CanRemoveInputtedData test
- LRQA-69098 Add CanNotPublishBlankRequiredField test
- LRQA-69098 Add CanInputDataOnDuplicatedField test
- LRQA-69098 Add CanRemoveDuplicatedField test
- LPS-137450 Use viewMode from form state instead
- LPS-137450 Fix test
- LPS-137450 Get viewMode from state and not from config
- LRQA-68051 Add new AWS integration test batch
- LRQA-68051 Remove un-needed since configuration is handled at the batch level
- LRQA-68051 Update generated file replacement
- LRQA-68051 Remove un-needed
- LRQA-68051 Add the property to the compiled bundle, not to the repo
- LRQA-68051 Use property to set aws store property since it will get overwritten in prepare-portal-ext properties if we use it manually
- LRQA-68051 Get property from Poshi testcase only if it is not yet set
- LRQA-68051 Property isn't storing globally so pass it down
- LRQA-68051 Rename and sort
- LRQA-68051 Set default for attribute to make it optional
- LRQA-68051 SF
- LPS-135924 Add macro to view and delete publish task
- LPS-135924 Add locator for publication pop-up window
- LPS-135924 Add test to assert publication processes message
- LPS-135924 Update case to assert validation error message
- LPS-135924 Update macro to assert the info of copy site pages variation
- LPS-135924 Add macro to view variation tooltip message
- LPS-135924 Add case to assert staging variation info
- LPS-135924 Add test to assert page variation info in publish screen
- LPS-135924 Add test to assert publish template info
- LPS-135924 Add macro to switch tab
- LPS-135924 Add macro to configure schedule time
- LPS-135924 Add test to assert scheduled publication info
- LPS-135924 Add macro to view system settings
- LPS-135924 Add test to assert staging system settings info
- LPS-135924 Expand macro to delete instance site
- LPS-135924 Add test to assert validation errors under remote staging
- LPS-135924 Add groovy script
- LPS-135924 Update macro to execute long-time script
- LPS-135924 Refactor macro for publishing to live
- LPS-135924 Update macro to skip assert process result when it's a long process
- LPS-135924 Add case to assert long publication process message
- LPS-137330 fill label as is the field that can be updated (name can’t anymore)
- LPS-128834 Add path for disabled expiration date fields
- LPS-128834 Add macro for view expired document notification
- LPS-128834 Add publish expired DM and update set expiration date
- LPS-128834 Make the macro name more generic
- LPS-128834 Add tests for manage expiration date
- LRAC-8707 Partial revert 241a55326337b9785d6aa8fdd594fe62e9ab6785
- LRQA-69456 Go to staging site
- LRQA-69456 Remove duplicated steps
- LRQA-69456 Publish to live before viewing the folder
- LRQA-69456 Update testcase name
- LRQA-69197 Add testcase to View XSS in Asset Publisher
- LRQA-69197 Add locator to locate Abstract via AP
- LRQA-69197 Add macro to add Abstract Via AP
- LPS-137312 Update correct method name for commerce according COMMERCE-6570  master: c00c32bf59de63ca7924a559c35740d2008ac626
- LPS-137312 SF, sort
- LPS-137549 Support for services with no type or type of Object.
- LPS-137549 Remove com.liferay.registry usage from integration test
- LPS-77699 Update Translations
- LPS-137548 Add page before navigation
- LPS-137548 Update testcase name
- LPS-137548 Add page first
- LPS-137559 Add KB article instead of child kb article
- LPS-137558 Update KB title and content value
- LPS-137560 Update page name
- LPS-137560 Update KB title names
- LPS-137572 Add KB article instead of child article
- LPS-137574 Add MB via portal to avoid viewing issue for guset
- LPS-137578 Add and view the MB with UTF characters via portal
- LPS-136661 Add a padding at the bottom of field to make all dropdown options invisble
- LPS-136661 Hugo SF
- LPS-137475 Translated languages hreflang tag should be generated on display page
- LPS-135531 Use "name" field as fallback
- LPS-135531 Show success message in layout admin
- LPS-135531 Sort
- LPS-135942 Create ExportDataDefinitionMVCResourceCommand
- LPS-135942 Field option should be tranformed to json
- LPS-135942 Data definition already contain a property for data layouts
- LPS-135942 Adapt integration test cases
- LPS-135942 Adapt util to deal with json objects options as well
- LPS-135942 Make sure to test the fix
- LPS-135942 A localized value can be a JSONArray as well as a JSONObject
- LPS-135942 Add unit tests to cover those cases
- LPS-135942 rename
- LPS-135942 about to tip over
- LPS-137361 Refactor to remove _createObjectField and use ObjectFieldUtil directly
- LPS-137474 always add the site default locale to the availables locales to show a default fallback
- LPS-137474 change test to pass new behavior
- LRQA-69295 Document and Media test stubs
- LPS-136864 SF, rename finder name
- LPS-136864 buildService
- LPS-136864 Update references
- LPS-136864 SF, rename finder name
- LPS-136864 buildService
- LPS-136864 Update references
- LPS-137580 Fix selector
- LPS-137580 Update item actions index
- LRQA-69405 - Activate WorkflowMetricsReindex test
- LPS-137108 checking if pages are on interval of another jump
- LPS-137108 make this private, can you also do the same for 'protected jumpPage' unless it needs to be protected? Thx.
- LPS-136388 Skip DL validation for non DL repositories
- LPS-136388 Tests
- LPS-134179 Update the condition to set the slaResult on the script to update sla's of the instance
- LRAC-8283 Add interests card path and macro
- LRAC-8283 Add testcase that shows what the top interests are
- LRAC-8283 Add default time period task
- LRAC-8283 Add path for empty cards
- LRAC-8283 Add macro for asserting empty interests card
- LRAC-8283 Remove other tests
- Record reference to liferay-portal/master-private with git-commit-portal-private as 7dc0cd6e43be14cf0e3bc4816074690f6d3517dc
- LPS-137212 Export getCollectionFilterValue and setCollectionFilterValue
- LPS-137212 Update collection-filter-category to use CollectionFilterRegister
- LPS-137212 Call CollectionFilterRegister on render
- LPS-137212 Fix singleSelection checked item
- LPS-137337 Add method to obtain the configuration of the filter
- LPS-137337 Add a method to obtain the key
- LPS-137337 Rely on getFilterKey instead of the property
- LPS-137337 Update GetCollectionFiltersMVCResourceCommand to add more information
- LPS-137337 Load filter specific configuration
- LPS-137337 Add configuration to the category filter
- LPS-137337 Extract function to be reused
- LPS-137337 Reuse function and remove not needed parameters
- LPS-137337 Remove configuration, this will be part of each filter
- LPS-137337 Move language keys
- LPS-137337 Update config
- LPS-137337 buildLang
- LPS-137337 baseline
- LPS-137337 Return a String to mimic similar APIs
- LPS-137337 SF
- LPS-137224 Make export dialog not resizable
- LPS-137444 Use a portalExecutor instead of a MessageListener to run the graphWalker operations in a separated threadPool
- LPS-137444 Apply to usage
- LPS-137444 Add the ability to wait for the graph traversal to finish
- LPS-137444 Not needed anymore
- LPS-137444 Propagate to layers above
- LPS-137444 Regen
- LPS-137444 Add SF exception
- LPS-137444 Baseline
- Revert "LRAC-8396 Fix failure about selecting date"
- LRAC-8514 Add case to show the number of Unique Visitors and Views
- LRAC-8517 Add case to time filter by Last 180 Days in Pages overview
- LRAC-8517 Rename case
- LRAC-8515 Add case to time filter by Last Year in Pages overview
- LRAC-8515 Rename case
- LRAC-8516 Add case to time filter by Custom Range in Pages overview
- LRAC-8516 Rename case
- LRAC-8516 Sort cases
- LRAC-8516 Use select function
- LRAC-8516 Quarantine and add comments
- LRAC-8515 Quarantine and add comments
- LRAC-8514 Quarantine and add comments
- LRAC-8517 Quarantine and add comments
- COMMERCE-5675 buildService
- COMMERCE-6187 + COMMERCE-5675 buildREST
- COMMERCE-6187 users nested field for organizations
- COMMERCE-6187 childOrganizations nested field
- COMMERCE-6187 organization number of users and accounts
- COMMERCE-6188 users nested field for account
- COMMERCE-6188 number of users for account
- COMMERCE-6187 add accounts nested field for organization
- COMMERCE-5675 add new endpoints for assigning users with roles
- COMMERCE-5675 add new organization service methods that return the added user
- COMMERCE-5675 implement method for new headless endpoints
- COMMERCE-5675 headless-admin-user baseline
- COMMERCE-5675 always use DTOConverter to be consistent
- COMMERCE-5675 fix tests
- COMMERCE-5675 use transformToList method
- COMMERCE-5675 buy space
- COMMERCE-5675 Don't use weird naming. We have a pattern to deal with conflicts that add information instead of hiding information
- COMMERCE-5675 Inline
- COMMERCE-5675 Inline more
- COMMERCE-5675 SF
- COMMERCE-5675 Inline
- COMMERCE-5675 Inline
- COMMERCE-5675 Inline
- COMMERCE-5675 externalReferenceCode is readOnly property
- COMMERCE-5675 Inline OrganizationResourceImpl
- COMMERCE-5675 Use GetterUtil
- Revert "LPS-134038 baseline"
- Revert "LPS-134038 Add missed or remove extra values correctly"
- LRAC-8317 Add PeriodFilter180Days Test
- LRAC-8317 SF
- LRAC-8296 Path used by macro and testcase
- LRAC-8296 Add macro to assert top pages entry by index
- LRAC-8296 Add ShowTop5EntrancePages Test
- LRAC-8296 SF
- LRAC-8318 Add PeriodFilterLastYear Test
- LRAC-8318 SF
- LPS-137357 Update the reindex request url
- LPS-137357 Add graphQL integration test for reindex/statuses
- LRAC-8448 Add AudienceCardShowsExpectedAmountKnowAndAnonymousIndividualsInWC testcase
- COMMERCE-7001 Add property test.name.skip.portal.instance for all tests into CPCommerceSpecifications
- COMMERCE-7001 Add property test.name.skip.portal.instance for RemoveAChannelFilter
- LPS-136864 SF, rename finder name
- LPS-136864 SF, rename finder name
- LPS-136864 buildService
- LPS-136864 Update references
- LPS-136864 SF, rename finder name
- LPS-136864 buildService
- LPS-136864 Update references
- LPS-137335 HTML Fragment Editor Modal unisolate the modal so ace editor styles still apply
- LRCI-2447 Find axis builds even when the label_exp is not set
- LRCI-2447 Add methods to get the slave labels from various test class groups
- LRCI-2447 Write 'test.batch.slave.label' into the job test properties file
- LRCI-2447 Partition axis test class groups by the slave label
- LRCI-2447 Use a constant
- LRCI-2447 prep next
- LRQA-69440 - Quarantine KaleoDesigner tests
- COMMERCE-6905 get list of pins from RestAPi + SF
- COMMERCE-6905 deleted diagram tests
- LRAC-8479 Add a csv file with contacts age
- LRAC-8479 Add locator for number input
- LRAC-8479 Add macro to edit number criterion
- LRAC-8479 Add case to create segment with number property
- LPS-136736 Create editing screen to update object field
- LPS-136736 buildLang
- LPS-136736 SF
- LPS-136736 Add objectDefinition as an attribute for the edit object field renderRequest
- LPS-136736 Allow editing the name and type fields when the object is not yet published
- LPS-136736 Disable field when object is not published
- LPS-136736 SF
- LPS-136736 SF
- LRAC-8095 Add CanDeleteCustomAssetReport Testcase
- LRAC-8095 SF
- LRAC-8402 Add AudienceCardShowsExpectedAmountKnowAndAnonymousIndividualsInDM Testcase
- LRQA-69471 Temp disable poshi portion of the license test until it can be stabilized on CI
- LRAC-8707 Add macro to assert event property value
- LRAC-8707 Add case to check webContentViewed properties
- LRAC-8707 Rename case
- LRAC-8706 Add case to check webContentClicked properties
- LRAC-8706 Rename case
- LRAC-8266 Change disconnectDXPFromAnalyticsCloud macro
- LRAC-8266 Add SitesReportPageHasEmptyStateIfNoDataSourceConnect testcase
- LRAC-8594 Update locator for delete button of data source
- LRAC-8594 Update locator for delete confirmation message
- LRAC-8594 Update locator for confirmation input
- LRAC-8594 Add a csv file with contact job title
- LRAC-8594 Assert individuals removed segment after deleting data source
- LRQA-69470 Temporary workaround for race condition between search and scheduler during upgrade
- LRQA-69470 SF
- LPS-137541 Normalize value to prevent issues when pasting hexcode
- LPS-137471 Test automation for Type column
- LPS-137471 SF
- LPS-137232 LPS-137314 Add Label and Plural Label fields in the object definition and add Label field in the object fields
- LPS-137232 LPS-137314 buildLang
- LPS-137562 Create new module for keyword filter
- LPS-137562 Add filter implementation
- LPS-137562 Add filter view
- LPS-137562 buildLang
- LPS-137562 Add js component to handle the interactions
- LPS-137562 Set default
- LPS-133587 json-storage-service: Add test for and fix null value searching.
- LPS-133587 json-storage-service: Add type search methods.
- LPS-133587 json-storage-api: Build Service.
- LPS-133587 json-storage-api: Versioning.
- LPS-133587 json-storage-test: Add test coverage for type searching.
- LPS-133587 portal-search-spi: Add IndexReindexer interface so that application and developer indexes can be reindexed
- LPS-133587 portal-search-spi: baseline
- LPS-133587 portal-search-admin-web: Add buttons to trigger reindexing of application and developer indexes
- LPS-133587 portal-search-tuning-rankings-web: Rename fields
- LPS-133587 portal-search-tuning-rankings-web: Add RankingJSONStorageHelper to store json in the database
- LPS-133587 portal-search-tuning-rankings-api: Add RankingsDatabaseImporter interface
- LPS-133587 portal-search-tuning-rankings-web: Add RankingsDatabaseImporterImpl so that any existing data in the ranking indexes can be copied to the database
- LPS-133587 portal-search-tuning-rankings-web: Replace RankingIndexWriter with RankingStorageAdapter so that rankings get written to both the database and index
- LPS-133587 portal-search-tuning-rankings-web: Implement RankingIndexReindexer so that rankings can be reindexed
- LPS-133588 portal-search-tuning-synonyms-web: Rename fields
- LPS-133588 portal-search-tuning-synonyms-web: Add SynonymSetJSONStorageHelper to store json in the database
- LPS-133588 portal-search-tuning-synonyms-api: Add SynonymSetsDatabaseImporter interface
- LPS-133588 portal-search-tuning-synonyms-web: Add SynonymSetsDatabaseImporterImpl so that any existing data in the synonym indexes can be copied to the database
- LPS-133588 portal-search-tuning-synonyms-web: Replace SynonymSetIndexWriter with SynonymSetStorageAdapter so that synonyms get written to both the database and index
- LPS-133588 portal-search-tuning-synonyms-web: Implement SynonymSetIndexReindexer so that synonyms can be reindexed
- LPS-133588 Wordsmith
- COMMERCE-6497 batch-planner-service - expose new method
- COMMERCE-6497 batch-planner - Autogenerated
- LPS-133588 my bad
- LRAC-8320 Path used by PropertyFieldWhenNoProperty Test
- LRAC-8320 Add PropertyFieldWhenNoProperty Test
- LRAC-8320 SF
- LRQA-69445 Quarantine failing test RightToLeftInfrastructure#RTLStylesAppliedToPageLayout
- LPS-77699 Update Translations
- LRQA-69254 Update the update user locator
- LPS-137547 Add path for the document href
- LPS-137547 Update macro for expanding document info panel
- LPS-137630 Update parameters to use absolute value format
- LPS-137632 Add property to use higher memory slaves
- LPS-137465 Also capture log in the test
- LPS-135846 Display commented entity in context
- LRQA-69272 Add test stubs
- LRQA-69272 Create IMAGE_DESCRIPTION_INDEXED path
- LRQA-69272 Add inputDataInImageField test
- LRQA-69272 Add CanBeUploaded test
- LRQA-69272 Add assertWebContentTitle
- LRQA-69272 Add CanImagePreviewDisplayedAfterEditing test
- LRQA-69272 Create CUSTOM_FIELD_IMAGE_PREVIEW_INDEXED and CUSTOM_FIELD_BUTTON_INDEXED paths
- LRQA-69272 Create clearImageField and assertImageNotPresent macros
- LRQA-69272 Add CanClearUpload test
- LRQA-69272 Add CanEditUpload test
- LRQA-69272 Add CanNotPublishBlankRequiredField test
- LRQA-69272 Add BUTTON_LABEL_INDEXED path
- LRQA-69272 Fix inputDataInImageField macro
- LRQA-69272 Add CanInputDataOnDuplicatedField test
- LRQA-69272 Add CanRemoveDuplicatedField test
- LRQA-69272 Add test descriptions
- LRQA-69272 Adjust test descriptions
- LRQA-69272 Reorder paths
- LRQA-69272 Add explicit index in inputDataInImageField macro
- LRQA-69272 Format macros
- LRQA-69272 Unify BUTTON_LABEL_INDEXED and CUSTOM_FIELD_BUTTON_INDEXED paths
- LRQA-69272 Improve CanEditUpload test
- LRQA-69272 Remove duplicated test
- LRQA-69272 Adjust CanInputDataOnDuplicatedField test
- LRQA-69272 Rename tests
- LRQA-69272 Use DEBuilder.addField macro
- LRQA-69272 Use DEBuilder.assertFieldNotPresent macro
- LRQA-69272 Add IMAGE_INPUT_INDEXED path
- LRQA-69272 Rename CUSTOM_FIELD_IMAGE_PREVIEW_INDEXED path
- LRQA-69272 Add assertDataInImageField macro
- LRQA-69272 Use DERenderer.assertDataInImageField macro
- LRQA-69272 Fix path indexes
- LPS-131583 Add target to unzip download temp file
- LPS-131583 Add macro to assert if folder existe in lar file
- LPS-131583 Add test to assert asset links can be configured when export
- LPS-137553 Add entry for new version
- LPS-137553 rename
- LRAC-8706 Add macro to get propertyId
- LRAC-8706 Add macro to get dxpInstanceId
- LRAC-8706 Add macro to get request common property value
- LRAC-8706 Add macro to assert request common properties value
- LRAC-8706 Modify locator to make it reusable
- LRAC-8706 Add locator for header title
- LRAC-8706 Add locator for header description
- LRAC-8706 Add steps to assert request common properties value
- LPS-137002 Copy navigation menu to draft layout type settings in case of original layout has one.
- LPS-137002 SF
- LPS-137002 rename
- LPS-137147 Add support for fragments hiding to master layout items
- LPS-137147 Add support for fragment hiding from structure tree
- LPS-137147 Apply margin to fieldsets without label only in common styles
- LPS-137147 Show restore button only for responsive viewports
- LPS-137147 Add popover to viewport size selector buttons
- LPS-137147 Pass hasHiddenAncestor to children so we don't have to calculate each time
- LPS-137147 Show hidden icon also for master layout items
- LPS-137147 Apply background to master layout items
- LPS-137147 Add margin to visibility button when remove button is not present
- LPS-137147 Update locator for tree view delete button
- LPS-137147 Adapt tests
- LPS-137147 buildLang
- LPS-137147 Wordsmith
- LPS-137147 Regen
- LPS-137566 Update and standardize templates help text
- LPS-137566 Wordsmith
- COMMERCE-7031 commerce-shop-by-diagram-service change field number to sequence
- COMMERCE-7031 commerce-shop-by-diagram-service change field number to sequence in service classes
- COMMERCE-7031 commerce-shop-by-diagram-service change field number to sequence in Contributor class
- COMMERCE-7031 commerce-shop-by-diagram semantic versioning (gw buildService)
- COMMERCE-7031 commerce-shop-by-diagram autogenerated code (gw buildService)
- COMMERCE-7031 commerce-shop-by-diagram SF
- COMMERCE-7056 headless-commerce-shop-by-diagram-impl change number to sequence (yaml file)
- COMMERCE-7056 headless-commerce-admin_shop-by-diagram autogenerated code (gw buildREST)
- COMMERCE-7056 headless-commerce-admin_shop-by-diagram change number to sequence
- COMMERCE-7056 Sort
- COMMERCE-7084 replaced deprecated methods usage with supported ones
- LPS-137068 LPS-137077 Adjust methods to pass label and plural label values to service layer
- LPS-137514 Take into account singular case
- LPS-137514 buildLang
- LPS-137514 Spell it out if it's less than 9 https://www.scribendi.com/academy/articles/when_to_spell_out_numbers_in_writing.en.html#:~:text=A%20simple%20rule%20for%20using,ten)%20are%^Cwritten%20as%20numerals.
- Revert "LPS-137514 Spell it out if it's less than 9 https://www.scribendi.com/academy/articles/when_to_spell_out_numbers_in_writing.en.html#:~:text=A%20simple%20rule%20for%20using,ten)%20are%^Cwritten%20as%20numerals."
- COMMERCE-6975 Add orderType field to order model
- COMMERCE-6975 Add commerceOrderType to service methods
- COMMERCE-6975 Add upgrade process for order condition type
- COMMERCE-6975 Increase schema version
- COMMERCE-6975 Pass orderTypeId in addCommerceOrder from MVCAction
- COMMERCE-6975 Don't need to reindex here
- COMMERCE-6975 Generated buildUpgradeTable
- COMMERCE-6975 Refactor commerce order local service implementation
- COMMERCE-6975 Refactor commerce order remote service implementation
- COMMERCE-6975 Remove userId from remote service
- COMMERCE-6975 Use new method in order http helper
- COMMERCE-6975 Regen services
- COMMERCE-6975 Fixed usages
- COMMERCE-6975 Use new methods in headless resources
- LRQA-69473 Workflow DDL test stubs
- LPS-135024 Correct name for nextEditableProcessorUniqueId
- LPS-135024 Use parentId for getCollectionItems if the item type is editable
- LPS-135024 Use getFirstControlsId when inline text is edited
- LPS-135024 Adapt tests
- LPS-135024 toControlsId is not available here so just use fromControlsId to the processorId to check if it is being edited
- LPS-137162 Create a file for the upgrade report and add the currently set important properties for the upgrade
- LPS-137162 Add the Liferay version before and after the upgrade
- LPS-137162 Add the database information being used
- LPS-137162 Improve information gathered and better format code
- LPS-137162 Get configuration from database for rootDir
- LPS-137162 Simplify the condition
- LPS-137162 We added the schemaVersion field in 7.0
- LPS-137162 Make it simpler
- LPS-137162 Simplify initialization and we must never change the scope of a method due to the tests. They should be private
- LPS-137162 Reorganize and print also the expected values
- LPS-137162 Since for now we only generate the report from the upgrade tool, generate it in the upgrade tool directory. Also generate a reports folder
- LPS-137162 Manual SF
- LPS-137162 Fix typo
- LPS-137162 There is no need to exclude this SF rule
- LPS-137162 Refactor
- LPS-137162 Change the exit signal to the end of the process to avoid close the JVM without generating the report
- LPS-137162 Use always the proper path
- LPS-137162 Manual SF
- LPS-137162 Delete incorrect file
- LPS-137162 Make it more technical since it's not just for humans but used programmatically
- LPS-137162 Easier on the eyes
- LPS-137162 Wrong count
- LPS-137162 Sort
- LPS-137162 Update count
- LPS-137162 Prefix
- LPS-137162 Wordsmith
- LPS-137162 Rename
- LPS-137162 Wordsmith
- LPS-137563 Renable acceptance cases since LPS-137335 get fixed
- LPS-137343 Removes unnecessary parameters
- LPS-137343 SourceObject can be null, so prevent null pointer exception
- LPS-137343 Prevent null pointer exception since fragmentEntriesEnumeration or fragmentCompositionsEnumeration can be null
- LPS-137343 Adds new method to get the info filter class name
- LPS-137343 Uses new method
- LPS-137343 Adds new method to get the configuration field value
- LPS-137343 Implements new method
- LPS-137343 Adds new method to set and get the filter values
- LPS-137343 Calculate the filter values attending on url parameters
- LPS-137343 Adds new interface to creates an InfoFilter using the filterValues
- LPS-137343 SF - Reorder
- LPS-137343 Register new interface
- LPS-137343 Rename
- LPS-137343 Implements new interface and simplify the code
- LPS-137343 No needed
- LPS-137343 Avoid null pointer exception since infoRequestItemProvider can be null
- LPS-137343 Uses new interface and filter values to obtain the InfoFilter
- LPS-137343 Removes unnecessary jsps
- LPS-137343 Render FragmentCollectionFilter attending on filter key
- LPS-137343 Rename to filter key to match with getFilterKey() on FragmentCollectionFilter
- LPS-137343 If the filter is not configure the fragmentCollectionFilter is null, so we should not render it
- LPS-137343 build.gradle
- LPS-137343 baseline
- LPS-137343 Sort
- LPS-135024 Not needed parameters
- COMMERCE-7085 Fixed pins creation on front store
- COMMERCE-7088 Fixed pins label
- LPS-137540 This preparedStatement should support batch processing
- LPS-136141 move the move partially translated configuration to instance and site level
- LPS-136141 now we use the LayoutSEOGroupConfiguration to know if the configuration is enabled
- LPS-136141 Autogenerated
- LPS-136141 change test to pass new behavior
- LPS-137356 use Hystrix plugin to override default properties strategy
- LPS-137356 add tests
- LPS-137356 reuse variables
- LPS-137356 rename
- LPS-137356 rename
- LPS-137356 rename
- LPS-137356 rename
- LPS-137356 rename
- LRQA-69493 - Quarantine AddEndNodeEditNameAndDesciptionAndDeleteViaViewTab test
- LPS-137565 Fix LPS for Fragments
- LPS-137565 Fix LPS for Content Display
- LPS-137565 Fix LPS for Collection Display
- LPS-137565 Fix LPS for Master Page Templates
- LPS-137565 Fix LPS for Video URL cases
- LPS-130662 Ignore for now
- LPS-130662 INFO
- LPS-100336 ensure we are using the cache
- LRAC-8585 Create DISABLED_MEMBER path
- LRAC-8585 Create clickCancelButton macro
- LRAC-8585 Add CantDuplicateUserToStaticSegment testcase
- LRAC-8585 SF
- LPS-100336 add more tests for the cache field
- LPS-100336 This should work but does not, comment out for now
- LRAC-8313 Add session technology device testcase
- LRAC-8312 Add session technology browser testcase
- LRAC-8313 Quarantine tests
- LRAC-8280 Add VISITORS_LEGEND path
- LRAC-8280 Add CanShownAnonAndKnownVisitorsLegend testcase
- LPS-137543 Add JSON macros for Objects
- LPS-137634 Escape label
- COMMERCE-7087 Removed auto mapping button
- LPS-136864 Avoid duplicate finder names
- LPS-136864 SF, rename finder name
- LPS-136864 buildService
- LPS-136864 Update references
- LPS-136864 Use all caps for specific names
- LPS-135943 Create data-engine-rest-test-util module
- LPS-135943 Add integration test for new MVCResourceCommand
- LPS-135943 Uses toString method
- LPS-135943 Removes unnecessary function
- LPS-137452 - Show placeholder on search location field
- COMMERCE-6553 & COMMERCE-6555 Add configurations for default category and product layouts
- COMMERCE-6553 Add selection section in channel admin for default category display page
- COMMERCE-6553 Look for a default category display layout before searching for portlet
- COMMERCE-6555 Add selection section in channel admin for default product display page
- COMMERCE-6555 Look for a default product display layout before searching for portlet
- COMMERCE-6553 Add language keys
- COMMERCE-6553 Source formatting
- COMMERCE-6553 Regenerate language files (gradle buildLang)
- COMMERCE-6553 - gw baseline
- COMMERCE-6915 - As a content editor specialist I want to be able to map Product fields to elements while creating  a content page
- COMMERCE-6553 - Avoid Using *Util classes
- COMMERCE-6553 - "http://liferay.com/tld/commerce-ui" is missing
- COMMERCE-6553 bad copy and paste
- COMMERCE-6553 Rename
- COMMERCE-6553 SF
- LPS-135245 Add new undocumented portal.properties property that allows to our final customers to force the asyncronous indexation as a workaround until they fix their Elasticsearch server
- LPS-135245 avoid constantly getting this
- LPS-135245 rename
- LPS-135245 rename for clarity
- LPS-135245 match index.search.* in portal.properties
- LPS-135245 auto SF
- LRAC-8341 Create macro to filter pages by time period
- LRAC-8341 Add test to filter pages list by last year
- LRAC-8341 Replace macros to use prexisting ones
- LRAC-8423 Add AudienceCardShowsExpectedAmountKnowAndAnonymousIndividualsInForms testcase
- LRAC-8298 Add SEARCHED_KEYWORD path
- LRAC-8298 Fix connectDXPtoAnalyticsCloud macro
- LRAC-8298 Add ShowsKeywordsBeingSearched testcase
- COMMERCE-5674 Organization chart JS component with basic interactions
- COMMERCE-5674 sf + code review updates
- COMMERCE-5675 Org chart - Plus button + modal interactions
- COMMERCE-5675 Org chart - Dropdown menu on chart nodes with basic actions
- COMMERCE-5675 sf
- COMMERCE-5675 tests updated
- COMMERCE-5674 Capitalize titles
- COMMERCE-5675 fixes post review
- COMMERCE-5674 make this a sentence
- COMMERCE-5674 regen
- LPS-133587 portal-search-tuning-rankings-web: Dont import entries that are already in the database
- LPS-133588 portal-search-tuning-synonyms-web: Dont import entries that are already in the database
- LPS-137646 Add frontend tests for Fragments Hiding
- LPS-137099 Must use slash as delimiter to return true if string contains '/shared'
- LPS-137099 Make private
- LPS-137099 Add unit test
- LPS-137663 Fix for WebContentViewInfoPanel and DocumentViewInfoPanel
- LPS-137663 SF
- Revert "LPS-137663 SF"
- Revert "LPS-137663 Fix for WebContentViewInfoPanel and DocumentViewInfoPanel"
- COMMERCE-6702 Split end point and use accountId in get method
- COMMERCE-6702 Implement get by channelId and accountId
- COMMERCE-6574 Adjust Account Selector to use new order delivery api with accountId and channelId
- COMMERCE-6574 Adjust tests and mock data
- COMMERCE-6702 Regenerate Rest Files (gradle buildRest)
- COMMERCE-6702 SF
- LPS-86764 The module release entries are already being initialized in UpgradeModules
- LPS-86764 Use UpgradeModules class to initialize release entries
- LPS-86764 These upgrades aren't necessary with a fresh database
- LPS-86764 Missing cases
- LRAC-8429 Add FormsTechnologyCardShowsViewsByExpectedBrowser Test
- LRAC-8429 Add macro that goes into a technologies card tab
- LRAC-8429 Add path to find a inactive tab inside a card
- LRAC-8429 SF
- LRAC-8346 Add locator for metric bar
- LRAC-8346 Add locator for table entry info
- LRAC-8346 Add macro to view metric bar style
- LRAC-8346 Add macro to view table entry info
- LRAC-8346 Add case to assert sites acquisition card channels highest session
- LRAC-8348 Sort macros
- LRAC-8348 Add case to assert sites acquisition card source and medium highest session
- LRAC-8347 Add case to assert sites acquisition card referrers highest session
- LRAC-8347 Remove duplicate stub
- LRAC-8322 Paths used by macro and testcase
- LRAC-8322 Add addUserProperty and assertPropertyTitleList macros
- LRAC-8322 Add UserShouldOnlySeePropertiesAreInvitedByACAdminOrPropertiesWhichUserOwner Test
- LRAC-8322 SF
- LRQA-69325 Add assertions for account role type column
- LRQA-69325 Use Owned Account Role instead of Account Specific Role
- LRQA-69496 Move DDL specific test to DDL
- LRQA-69325 Sort
- LRQA-68382 Assert default filter in Accounts
- LRQA-68383 Separate editing name and editing status
- LRQA-69217 Rename test for clarity
- LPS-137171 Changes for predefinedValue in Boolean Field
- COMMERCE-6965 Remove deprecated methods
- COMMERCE-6965 Regen
- COMMERCE-6965 Baseline
- LPS-105380 Service Buidler *abc-service should not use abc.service.internal, but just abc.internal
- LRAC-8426 Add FormsLocationCardShowsViewsByExpectedLocation Test
- LRAC-8426 Add path to locate locations in geomap table
- LRAC-8426 Add macro to assert if a list of locations is present in geomap table
- LRAC-8426 SF
- LRAC-8155 Simplify locator
- LRAC-8155 Modify macro to delete csv data source
- LRAC-8155 Add case to delete csv data source and assert details from data source removed
- LRAC-8155 Add locator for loading animation
- LRAC-8155 Add steps to wait for loading
- LPS-136723 Use .markdown instead of .md
- LPS-136723 UTF-8
- LPS-136723 UTF-8 add back quote
- LPS-137542 SF
- LPS-105380 Order put calls in HashMapDictionaryBuilder
- LPS-105380 Sort
- LPS-105380 Use StringBundler.concat
- LPS-105380 SF
- LPS-105380 Use StringBundler.concat
- LPS-105380 SF
- LRAC-8490 Add testcase to order dynamic segment membership
- LRAC-8490 Add segments path to view specific order
- LRAC-8490 Add segments macro to view segments in specific order
- LPS-105380 Rename methods
- LPS-105380 build services
- LPS-105380 Update usage
- LPS-105380 baseline
- LPS-137652 Avoid infinite loops when fragment has no HTML
- LPS-137652 Use isNullOrUndefined
- LPS-137652 Add missing test
- LPS-137652 Only add id and className if needed
- LPS-137664 Validate collection filter configuration in service tracker
- LPS-137345 Fix date picker date selection
- COMMERCE-6975 Add order type to Order model yaml
- COMMERCE-6975 Return orderTypeId in cart DTO converter
- COMMERCE-6975 Pass orderTypeId to addCommerceOrder
- COMMERCE-6975 Sort
- COMMERCE-6975 regen
- LPS-135632 Add tests for each type of failing element
- LPS-135632 SF
- LPS-135632 Fixed macro
- LPS-135632 Added descriptions to the testcases
- LPS-135632 SF
- LPS-132411 Adding failing tests for LPS-137555
- LPS-132411 Adding method to get variations from several groupIds
- LPS-132411 Implementing for articles and documents
- LPS-132411 Retrieving variations from every group
- LPS-132411 Storing the groupId in the form variation to be able to include it in the name later
- LPS-132411 Appending group name to the variation name
- LPS-132411 Sort
- LPS-132411 rename
- LPS-137108 [follow-up] making it private
- LPS-129960 Do not set a timeout
- LPS-129960 Simplify
- Revert "LPS-130662 Ignore for now"
- LPS-130662 still breaks for me
- LPS-137535 Add name and type in the update object field method
- LPS-137535 buildService
- LPS-137535 Update only the label if the object is already published
- LPS-137535 Update custom object field integration test
- LPS-137535 match order in _addObjectField
- LPS-137535 I prefer to let good code speak for itself. When I do use comments, I generally use them just as headers/titles to make the chunks pop out, see testAddSystemObjectField
- LPS-137535 Not really needed since you never compare objectField with updateObjectField
- LPS-137535 locale.getLanguage() is not always the same as LanguageUtil.getLanguageId
- LPS-137535 clarity
- LPS-137535 consistency with line 317-318
- LPS-137535 let's line them all up like this
- LPS-137535 able, baker, charlie is easier to read than able, able2, able3
- LPS-137535 auto SF
- LPS-137535 Make the test pattern pop out
- LPS-137535 I was wrong, SF wants me to always put the expected var first
- LPS-105380 Use StringBundler.concat
- LPS-105380 SF
- LPS-105380 Use StringBundler.concat
- LPS-105380 SF
- LPS-105380 Use StringBundler.concat
- LPS-105380 SF
- LPS-137101 Add ObjectDisplayedToCollectionProdiver Test
- LPS-137101 SF
- LPS-137104 Update Test with API
- LPS-137349 Add CanSelectObjectStorageType Test
- LPS-137349 SF
- LPS-137349 Update Test with API
- LPS-137346 Update tearDown with API
- LPS-137346 Fix command name
- LPS-137517 Add the ability to filter condition or action fields by a setting
- LPS-137517 Not needed anymore
- LPS-137517 Add flags to fields that need them
- LPS-137517 Make sure to assert the flags during unit testing
- LPS-137517 sort
- LPS-137709 Ignore tests pending implementation
- LPS-137522 we can’t call this modelResourcePermission as it does not implement the methods that are called first, but it is not needed as relying in the default provider is enough
- LRQA-69177 Bump remote Elasticsearch to 7.14.0
- RELEASE-4048 Update Release Info ReleaseInfo.Java and ci.properties
